### PR TITLE
Workaround for problem with @example block

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,14 @@ using DocumenterCitations
 
 bib = CitationBibliography(joinpath(@__DIR__, "src/paleo_references.bib"))
 
+# Workaround for problem with @example block:
+# include that defines new AbstractReaction subtype is apparently invisible
+# to InteractiveUtils.subtypes()
+include("../examples/reservoirs/reactions_ex1.jl")
+include("../examples/reservoirs/reactions_ex2.jl")
+include("../examples/reservoirs/reactions_ex3.jl")
+include("../examples/reservoirs/reactions_ex5.jl")
+
 makedocs(bib, sitename="PALEOtutorials Documentation", 
 # makedocs(sitename="PALEO Documentation", 
     pages = [


### PR DESCRIPTION
include that defines new AbstractReaction subtype is apparently invisible
to InteractiveUtils.subtypes()