### PR TITLE
Update for Parameter simplifications (PALEOboxes v0.20.4), model vs run

### DIFF
--- a/examples/CPU/CPU_cfg.yaml
+++ b/examples/CPU/CPU_cfg.yaml
@@ -6,6 +6,9 @@
 ########################################################
 CPU_Zhang2020:
     parameters:
+        # model-wide Parameters
+        # These will be read by any Reaction Parameter that has 'external=true',
+        # or can be used to set any Reaction Parameter explicitly as eg 'external%CIsotope'
         CIsotope: IsotopeLinear       
         UIsotope: IsotopeLinear
     domains:

--- a/examples/CPU/CPU_examples.jl
+++ b/examples/CPU/CPU_examples.jl
@@ -16,17 +16,17 @@ include("CPU_reactions.jl")
 include("CPU_expts.jl")
 
 # baseline steady-state
-# run = CPU_expts([], comparedata)
+# model = CPU_expts([], comparedata)
 
 # LIP CO2 input
-run = CPU_expts([("LIP", 3e18)])
+model = CPU_expts([("LIP", 3e18)])
 
 # increase E
-# run = CPU_expts([("E", 2.0)])
+# model = CPU_expts([("E", 2.0)])
 # increase V
-# run = CPU_expts([("V", 2.0)])
+# model = CPU_expts([("V", 2.0)])
 
-initial_state, modeldata = PALEOmodel.initialize!(run)
+initial_state, modeldata = PALEOmodel.initialize!(model)
 
 # call ODE function to check derivative
 initial_deriv = similar(initial_state)
@@ -34,6 +34,7 @@ PALEOmodel.ODE.ModelODE(modeldata)(initial_deriv, initial_state , nothing, 0.0)
 println("initial_state", initial_state)
 println("initial_deriv", initial_deriv)
 
+run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
 
 println("integrate, ODE")
 # first run is slow as it includes JIT time

--- a/examples/CPU/CPU_expts.jl
+++ b/examples/CPU/CPU_expts.jl
@@ -9,7 +9,7 @@ function CPU_expts(expts)
     model = PB.create_model_from_config(
         joinpath(@__DIR__, "CPU_cfg.yaml"), 
         "CPU_Zhang2020"; 
-        modelpars=Dict(),
+        modelpars=Dict(), # optional Dict can be supplied to set top-level (model wide) Parameters
     )
         
     ###############################################
@@ -49,9 +49,7 @@ function CPU_expts(expts)
         end
     end
 
-    run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
-
-    return run
+    return model
 end
 
 

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -14,5 +14,5 @@ Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 
 [compat]
-PALEOboxes = "0.20.2"
+PALEOboxes = "0.20.4"
 PALEOmodel = "0.15.3"

--- a/examples/error_examples/run_ex5_flux_noisotope.jl
+++ b/examples/error_examples/run_ex5_flux_noisotope.jl
@@ -13,17 +13,19 @@ model = PB.create_model_from_config(
     "example5_flux_noisotope"
 )
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
-
 #########################################################
 # Initialize
 ##########################################################
 
-initial_state, modeldata = PALEOmodel.initialize!(run)
+initial_state, modeldata = PALEOmodel.initialize!(model)
 
 #####################################################################
 # Optional: call ODE function to check derivative
 #######################################################################
+
+# create a Run object to hold model and output
+run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+
 initial_deriv = similar(initial_state)
 PALEOmodel.ODE.ModelODE(modeldata)(initial_deriv, initial_state , nothing, 0.0)
 println("initial_state: ", initial_state)

--- a/examples/error_examples/run_ex5_reservoir_A_duplicate.jl
+++ b/examples/error_examples/run_ex5_reservoir_A_duplicate.jl
@@ -13,13 +13,11 @@ model = PB.create_model_from_config(
     "example5_reservoir_A_duplicate"
 )
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
-
 #########################################################
 # Initialize
 ##########################################################
 
-initial_state, modeldata = PALEOmodel.initialize!(run)
+initial_state, modeldata = PALEOmodel.initialize!(model)
 
 #####################################################################
 # Optional: call ODE function to check derivative
@@ -32,6 +30,10 @@ println("initial_deriv: ", initial_deriv)
 #################################################################
 # Integrate vs time
 ##################################################################
+
+# create a Run object to hold model and output
+run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+
 println("integrate, ODE")
 # first run is slow as it includes JIT time
 @time PALEOmodel.ODE.integrate(

--- a/examples/error_examples/run_ex5_reservoir_A_missing.jl
+++ b/examples/error_examples/run_ex5_reservoir_A_missing.jl
@@ -13,13 +13,11 @@ model = PB.create_model_from_config(
     "example5_reservoir_A_missing"
 )
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
-
 #########################################################
 # Initialize
 ##########################################################
 
-initial_state, modeldata = PALEOmodel.initialize!(run)
+initial_state, modeldata = PALEOmodel.initialize!(model)
 
 #####################################################################
 # Optional: call ODE function to check derivative
@@ -32,6 +30,10 @@ println("initial_deriv: ", initial_deriv)
 #################################################################
 # Integrate vs time
 ##################################################################
+
+# create a Run object to hold model and output
+run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+
 println("integrate, ODE")
 # first run is slow as it includes JIT time
 @time PALEOmodel.ODE.integrate(

--- a/examples/error_examples/run_ex5_reservoir_A_noisotope.jl
+++ b/examples/error_examples/run_ex5_reservoir_A_noisotope.jl
@@ -13,13 +13,11 @@ model = PB.create_model_from_config(
     "example5_reservoir_A_noisotope"
 )
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
-
 #########################################################
 # Initialize
 ##########################################################
 
-initial_state, modeldata = PALEOmodel.initialize!(run)
+initial_state, modeldata = PALEOmodel.initialize!(model)
 
 #####################################################################
 # Optional: call ODE function to check derivative
@@ -32,6 +30,10 @@ println("initial_deriv: ", initial_deriv)
 #################################################################
 # Integrate vs time
 ##################################################################
+
+# create a Run object to hold model and output
+run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+
 println("integrate, ODE")
 # first run is slow as it includes JIT time
 @time PALEOmodel.ODE.integrate(

--- a/examples/error_examples/run_ex5_syntax_error.jl
+++ b/examples/error_examples/run_ex5_syntax_error.jl
@@ -13,13 +13,11 @@ model = PB.create_model_from_config(
     "example5_syntax_error"
 )
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
-
 #########################################################
 # Initialize
 ##########################################################
 
-initial_state, modeldata = PALEOmodel.initialize!(run)
+initial_state, modeldata = PALEOmodel.initialize!(model)
 
 #####################################################################
 # Optional: call ODE function to check derivative
@@ -32,6 +30,10 @@ println("initial_deriv: ", initial_deriv)
 #################################################################
 # Integrate vs time
 ##################################################################
+
+# create a Run object to hold model and output
+run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+
 println("integrate, ODE")
 # first run is slow as it includes JIT time
 @time PALEOmodel.ODE.integrate(

--- a/examples/reservoirs/reactions_ex1.jl
+++ b/examples/reservoirs/reactions_ex1.jl
@@ -67,11 +67,11 @@ function initialize_example1(m::PB.ReactionMethod, (varsdata, ), cellrange::PB.A
 end
 
 # do method, called each main loop timestep
-function do_example1(m::PB.ReactionMethod, (varsdata, ), cellrange::PB.AbstractCellRange, deltat)
+function do_example1(m::PB.ReactionMethod, pars, (varsdata, ), cellrange::PB.AbstractCellRange, deltat)
     rj = m.reaction
 
-    # mol yr-1                   yr-1           mol
-    varsdata.decay_flux[] = rj.pars.kappa.v * varsdata.A[]
+    # mol yr-1                yr-1           mol
+    varsdata.decay_flux[] = pars.kappa[] * varsdata.A[]
 
     varsdata.A_sms[] -= varsdata.decay_flux[]
 

--- a/examples/reservoirs/reactions_ex2.jl
+++ b/examples/reservoirs/reactions_ex2.jl
@@ -31,11 +31,11 @@ function PB.register_methods!(rj::ReactionExample2)
 end
 
 # do method, called each main loop timestep
-function do_example2(m::PB.ReactionMethod, (varsdata, ), cellrange::PB.AbstractCellRange, deltat)
+function do_example2(m::PB.ReactionMethod, pars, (varsdata, ), cellrange::PB.AbstractCellRange, deltat)
     rj = m.reaction
 
     # mol yr-1                   yr-1           mol
-    varsdata.decay_flux[] = rj.pars.kappa.v * varsdata.A[]
+    varsdata.decay_flux[] = pars.kappa[] * varsdata.A[]
 
     varsdata.A_sms[] -= varsdata.decay_flux[]
 

--- a/examples/reservoirs/reactions_ex3.jl
+++ b/examples/reservoirs/reactions_ex3.jl
@@ -32,11 +32,11 @@ function PB.register_methods!(rj::ReactionExample3)
 end
 
 # do method, called each main loop timestep
-function do_example3(m::PB.ReactionMethod, (varsdata, ), cellrange::PB.AbstractCellRange, deltat)
+function do_example3(m::PB.ReactionMethod, pars, (varsdata, ), cellrange::PB.AbstractCellRange, deltat)
     rj = m.reaction
 
     # mol yr-1                   yr-1           mol
-    varsdata.decay_flux[] = rj.pars.kappa.v * varsdata.input_particle[]
+    varsdata.decay_flux[] = pars.kappa[] * varsdata.input_particle[]
 
     varsdata.input_particle_sms[] -= varsdata.decay_flux[]
 

--- a/examples/reservoirs/reactions_ex5.jl
+++ b/examples/reservoirs/reactions_ex5.jl
@@ -25,7 +25,7 @@ Base.@kwdef mutable struct ReactionExample5{P} <: PB.AbstractReaction
 end
 
 function PB.register_methods!(rj::ReactionExample5)
-    IsotopeType = rj.pars.field_data.v
+    IsotopeType = rj.pars.field_data[]
     vars = [
         PB.VarDepScalar("input_particle",           "mol",      "reservoir for input",
             attributes=(:field_data=>IsotopeType,)),
@@ -44,14 +44,14 @@ function PB.register_methods!(rj::ReactionExample5)
 end
 
 # do method, called each main loop timestep
-function do_example5(m::PB.ReactionMethod, (varsdata, ), cellrange::PB.AbstractCellRange, deltat)
+function do_example5(m::PB.ReactionMethod, pars, (varsdata, ), cellrange::PB.AbstractCellRange, deltat)
     rj = m.reaction
     (IsotopeType, ) = m.p
 
     # mol yr-1                   yr-1           mol
-    varsdata.decay_flux[] = rj.pars.kappa.v * @PB.isotope_totaldelta(IsotopeType, 
+    varsdata.decay_flux[] = pars.kappa[] * @PB.isotope_totaldelta(IsotopeType, 
                                                 PB.get_total(varsdata.input_particle[]), # total
-                                                varsdata.input_particle_delta[] + rj.pars.Delta.v) # delta
+                                                varsdata.input_particle_delta[] + pars.Delta[]) # delta
 
     varsdata.input_particle_sms[] -= varsdata.decay_flux[]
 

--- a/examples/reservoirs/run_ex1.jl
+++ b/examples/reservoirs/run_ex1.jl
@@ -10,13 +10,11 @@ include(joinpath(@__DIR__, "reactions_ex1.jl"))
 
 model = PB.create_model_from_config(joinpath(@__DIR__, "config_ex1.yaml"), "example1")
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
-
 #########################################################
 # Initialize
 ##########################################################
 
-initial_state, modeldata = PALEOmodel.initialize!(run)
+initial_state, modeldata = PALEOmodel.initialize!(model)
 
 #####################################################################
 # Optional: call ODE function to check derivative
@@ -29,6 +27,10 @@ println("initial_deriv: ", initial_deriv)
 #################################################################
 # Integrate vs time
 ##################################################################
+
+# create a Run object to hold model and output
+run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+
 println("integrate, ODE")
 # first run is slow as it includes JIT time
 @time PALEOmodel.ODE.integrate(

--- a/examples/reservoirs/run_ex2.jl
+++ b/examples/reservoirs/run_ex2.jl
@@ -10,13 +10,11 @@ include(joinpath(@__DIR__, "reactions_ex2.jl"))
 
 model = PB.create_model_from_config(joinpath(@__DIR__, "config_ex2.yaml"), "example2")
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
-
 #########################################################
 # Initialize
 ##########################################################
 
-initial_state, modeldata = PALEOmodel.initialize!(run)
+initial_state, modeldata = PALEOmodel.initialize!(model)
 
 #####################################################################
 # Optional: call ODE function to check derivative
@@ -29,6 +27,10 @@ println("initial_deriv: ", initial_deriv)
 #################################################################
 # Integrate vs time
 ##################################################################
+
+# create a Run object to hold model and output
+run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+
 println("integrate, ODE")
 # first run is slow as it includes JIT time
 @time PALEOmodel.ODE.integrate(

--- a/examples/reservoirs/run_ex3.jl
+++ b/examples/reservoirs/run_ex3.jl
@@ -10,13 +10,11 @@ include(joinpath(@__DIR__, "reactions_ex3.jl"))
 
 model = PB.create_model_from_config(joinpath(@__DIR__, "config_ex3.yaml"), "example3")
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
-
 #########################################################
 # Initialize
 ##########################################################
 
-initial_state, modeldata = PALEOmodel.initialize!(run)
+initial_state, modeldata = PALEOmodel.initialize!(model)
 
 #####################################################################
 # Optional: call ODE function to check derivative
@@ -29,6 +27,10 @@ println("initial_deriv: ", initial_deriv)
 #################################################################
 # Integrate vs time
 ##################################################################
+
+# create a Run object to hold model and output
+run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+
 println("integrate, ODE")
 # first run is slow as it includes JIT time
 @time PALEOmodel.ODE.integrate(

--- a/examples/reservoirs/run_ex4.jl
+++ b/examples/reservoirs/run_ex4.jl
@@ -10,13 +10,11 @@ include(joinpath(@__DIR__, "reactions_ex3.jl"))
 
 model = PB.create_model_from_config(joinpath(@__DIR__, "config_ex4.yaml"), "example4")
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
-
 #########################################################
 # Initialize
 ##########################################################
 
-initial_state, modeldata = PALEOmodel.initialize!(run)
+initial_state, modeldata = PALEOmodel.initialize!(model)
 
 #####################################################################
 # Optional: call ODE function to check derivative
@@ -29,6 +27,10 @@ println("initial_deriv: ", initial_deriv)
 #################################################################
 # Integrate vs time
 ##################################################################
+
+# create a Run object to hold model and output
+run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+
 println("integrate, ODE")
 # first run is slow as it includes JIT time
 @time PALEOmodel.ODE.integrate(

--- a/examples/reservoirs/run_ex5.jl
+++ b/examples/reservoirs/run_ex5.jl
@@ -11,13 +11,11 @@ include(joinpath(@__DIR__, "reactions_ex5.jl"))
 
 model = PB.create_model_from_config(joinpath(@__DIR__, "config_ex5.yaml"), "example5")
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
-
 #########################################################
 # Initialize
 ##########################################################
 
-initial_state, modeldata = PALEOmodel.initialize!(run)
+initial_state, modeldata = PALEOmodel.initialize!(model)
 
 #####################################################################
 # Optional: call ODE function to check derivative
@@ -30,6 +28,10 @@ println("initial_deriv: ", initial_deriv)
 #################################################################
 # Integrate vs time
 ##################################################################
+
+# create a Run object to hold model and output
+run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+
 println("integrate, ODE")
 # first run is slow as it includes JIT time
 @time PALEOmodel.ODE.integrate(

--- a/examples/solvers/run_ex5_Tsit5.jl
+++ b/examples/solvers/run_ex5_Tsit5.jl
@@ -11,13 +11,11 @@ include(joinpath(@__DIR__, "../reservoirs/reactions_ex5.jl"))
 
 model = PB.create_model_from_config(joinpath(@__DIR__, "../reservoirs/config_ex5.yaml"), "example5")
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
-
 #########################################################
 # Initialize
 ##########################################################
 
-initial_state, modeldata = PALEOmodel.initialize!(run)
+initial_state, modeldata = PALEOmodel.initialize!(model)
 
 #####################################################################
 # Optional: call ODE function to check derivative
@@ -30,6 +28,10 @@ println("initial_deriv: ", initial_deriv)
 #################################################################
 # Integrate vs time
 ##################################################################
+
+# create a Run object to hold model and output
+run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+
 println("integrate, ODE")
 # first run is slow as it includes JIT time
 @time PALEOmodel.ODE.integrate(


### PR DESCRIPTION
- Two Parameter-related updates in PALEOboxes v0.20.4 that make the syntax for
  Parameters similar to that of Variables, making code easier to read:
  - Parameters values can now be read using <par>[] instead of <par>.v
  - Optional 'pars' argument to method functions

- Earlier Parameter update from PALEOboxes v0.18.0:
  - use 'external=true' to enable Reaction Parameters to be set from model-wide Parameters in the .yaml
  (eg for isotope types that need to be changed across multiple reactions).

- Robustness fixes: use PALEOboxes.model in preference to PALEOmodel.Run, in
  particular use PALEOmodel.initialize!(model) instead of PALEOmodel.initialize!(run).
  This hopefully avoids potential issues where model and run could get out of sync.