### PR TITLE
Add CPU_modular example

### DIFF
--- a/examples/CPU/README.md
+++ b/examples/CPU/README.md
@@ -21,7 +21,7 @@ In `VS code`, right click on `PALEOtutorials/examples` or any subfolder in the f
  
 ## To run the CPU example with a default 3e18 mol C perturbation
    
-    julia> include("CPU.jl")
+    julia> include("CPU_examples.jl")
 
 This will run and plot output (NB: the first run will be slow as Julia JIT compiles the code).
 

--- a/examples/CPU_modular/CPU_modular_cfg.yaml
+++ b/examples/CPU_modular/CPU_modular_cfg.yaml
@@ -1,0 +1,233 @@
+########################################################
+# Carbon, Phosphorus, Uranian model from Clarkson etal (2018), Zhang etal (2020)
+# This effectively a stripped-down version of COPSE, 
+# omitting oxygen, sulphur, all sedimentary reservoirs,
+# and models for land and marine biota
+#
+# Modular version, with `atm` and `ocean` Domains
+########################################################
+CPU_Zhang2020:
+    parameters:
+        # model-wide Parameters
+        # These will be read by any Reaction Parameter that has 'external=true',
+        # or can be used to set any Reaction Parameter explicitly as eg 'external%CIsotope'
+        CIsotope: IsotopeLinear       
+        UIsotope: IsotopeLinear
+    domains:
+        fluxAtoLand:
+            
+            reactions:               
+                target:
+                    class: ReactionFluxTarget
+                    parameters:
+                        fluxlist: ["CO2::CIsotope"]                   
+
+        fluxRtoOcean:
+            
+            reactions:
+                target:
+                    class: ReactionFluxTarget                   
+                    parameters:                        
+                        fluxlist: ["DIC::CIsotope", "TAlk", "P", "U::UIsotope"]                 
+
+        global:
+            # scalar domain
+            
+            reactions:
+                
+                force_E:                    
+                    class: ReactionForceInterp
+                    parameters:
+                        force_times: [-1e30, 1e30]
+                        force_values: [1.0, 1.0]
+                    variable_links:
+                        F: E
+
+                force_W:                    
+                    class: ReactionForceInterp
+                    parameters:
+                        force_times: [-1e30, 1e30]
+                        force_values: [1.0, 1.0]
+                    variable_links:
+                        F: W
+
+                force_V:                    
+                    class: ReactionForceInterp
+                    parameters:
+                        force_times: [-1e30, 1e30]
+                        force_values: [1.0, 1.0]
+                    variable_links:
+                        F: V
+
+                force_D:                    
+                    class: ReactionForceInterp
+                    parameters:
+                        force_times: [-1e30, 1e30]
+                        force_values: [1.0, 1.0]
+                    variable_links:
+                        F: D                 
+
+                # set a constant time for (implicit) solar forcing in temp_global
+                tforce_solar:
+                    class: ReactionScalarConst
+                    parameters:
+                        constnames: ["tforce_solar"]
+                    variable_attributes:
+                        tforce_solar%initial_value: 0.0 # -250e6
+                    variable_links:
+                
+                temp_global:
+                    class: ReactionGlobalTemperatureBerner
+        
+                    parameters:                        
+                        k_c:                    4.0   # k_CO2 in Zhang (2020)
+                        k_l:                    7.4   # k_SL in Zhang (2020)
+                    variable_links:
+                        pCO2PAL:       atm.pCO2PAL   
+                        tforce: tforce_solar  # assume solar forcing at tforce_solar constant time
+
+                F_LIP:                    
+                    class: ReactionFluxPerturb
+                    parameters:
+                        field_data: external%CIsotope
+                        perturb_times: [-1e30, 1e30]
+                        perturb_totals: [0.0, 0.0]
+                        perturb_deltas: [0.0, 0.0]
+                    variable_links:
+                        F: atmocean.A_sms           # apply perturbation to the A reservoir
+                        FApplied: F_LIP    # save output for plotting etc
+
+        atm:
+            reactions:
+                force_pO2PAL:
+                    class: ReactionForceInterp
+                    parameters:
+                        force_times: [-1e30, 1e30]
+                        force_values: [1.0, 1.0]
+                    variable_links:
+                        F: pO2PAL
+
+                transfer_AtoLand:
+                    class: ReactionFluxTransfer
+                    parameters:
+                        input_fluxes:         fluxAtoLand.flux_$fluxname$
+                        output_fluxes:        $fluxname$_sms
+                        transfer_multiplier:  -1.0
+                    variable_links:
+                        output_CO2:           atmocean.A_sms  # no CO2 reservoir, so wire up to A
+ 
+
+        land:
+            reactions:
+                land_CPU:
+                    class: ReactionLandCPU
+
+                    parameters:
+                        # Carbon  cycle
+                        # A0 see ReactionReservoirScalar A 
+                        # k_d:         8.0e12       # degassing
+                        # k_w:         8.0e12       # silicate weathering
+                        # k_ox:        9.0e12       # oxidative weathering
+                        # k_carb:      16e12        # carbonate weathering/burial
+                        # k_torg:      4.5e12       # terrestrial organic C burial
+
+                        # Carbon isotopes
+                        # delta_LIP see ReactionFluxInterp LIP forcing
+                        # delta_in:    -5.0         # composition of other inputs
+                        # Delta:       16.0         # organic fractionation factor 25.0 - 9.0 **relative to atmospheric CO2**
+
+                        # Phosphorus cycle
+                        # P0 see ReactionReservoirScalar P
+                        # k_Pw:        72e9         # phosphorus weathering
+                    
+                        # Uranium isotopes
+                        # U0 see ReactionReservoirScalar U
+                        # k_riv:        40e6        # river input
+                        # delta_riv:   -0.26        # Composition of river input
+
+        atmocean:
+            reactions:
+                reservoir_A:
+                    class: ReactionAtmOcean_A
+                    parameters:                        
+                        f_atfrac:   quadratic
+                        delta_atm_ocean: true # provide fractionation for atm pCO2, ocean DIC
+                        fix_cisotopefrac_T: true # calculate fractionation for fixed 15C temperature
+                    
+                    variable_attributes:
+                        A:norm_value:           3.2e18
+                        A:initial_value:        3.2e18
+                        A:initial_delta:        1.8206  # per mil
+
+                    variable_links:
+                        # TEMP:                   global.TEMP
+                        pCO2*:                  atm.pCO2*
+                        D_atmCO2_A:             atm.D_atmCO2_A
+                        CO2_delta:              atm.CO2_delta
+                        D_oceanDIC_A:           ocean.D_oceanDIC_A
+                        DIC_delta:              ocean.DIC_delta
+
+        ocean:
+            reactions:
+                reservoir_P:
+                    class: ReactionReservoirScalar
+                    
+                    variable_links:
+                        R*: P*
+                    variable_attributes:
+                        R:norm_value:           3.1e15
+                        R:initial_value:        3.1e15
+
+                reservoir_U:
+                    class: ReactionReservoirScalar
+                    parameters:
+                        field_data: external%UIsotope
+                    
+                    variable_links:
+                        R*: U*
+                    variable_attributes:
+                        R:norm_value:           1.9e13
+                        R:initial_value:        1.9e13
+                        R:initial_delta:        -0.36  # per mil
+
+                ocean_CPU:
+                    class: ReactionOceanCPU
+
+                    parameters:
+                        # f_anoxic0:   0.0025     # ocean anoxia present day anoxic fraction
+                        # k_anox:      12.0       # ocean anoxia sharpness of transition
+                        # k_u:         0.5        # ocean anoxia nutrient utilization efficiency
+
+                        # Carbon  cycle
+                        # A0 see ReactionReservoirScalar A 
+                        # k_morg:      4.5e12       # marine organic C burial
+
+                        # Carbon isotopes
+                        # Delta:       25.0         # organic fractionation factor **relative to DIC**
+
+                        # Phosphorus cycle
+                        # P0 see ReactionReservoirScalar P
+                        # k_OrgP:      18e9         # organic P burial
+                        # k_FeP:       18e9         # Iron-sorbed P burial
+                        # k_CaP:       36e9         # Ca-bound P burial
+                        # CPoxic:      250.0        # oxic (C/Porg) burial ratio
+                        # CPanoxic:    1000.0       # anoxic (C/Porg) burial ratio
+
+                        # Uranium isotopes
+                        # U0 see ReactionReservoirScalar U
+                        # k_anoxic:     6e6         # anoxic sink
+                        # k_other:      34e6        # other sinks combined
+                        # Delta_anoxic: 0.6         # Anoxic sink fractionation
+                        # Delta_other:  0.005       # Other sinks fractionation
+
+                    variable_links:
+                        DIC_sms:    atmocean.A_sms   # no DIC reservoir, so wire up to atmocean A instead
+                    
+     
+                transfer_RtoOcean:
+                    class: ReactionFluxTransfer
+                    parameters:
+                        input_fluxes:         fluxRtoOcean.flux_$fluxname$
+                        output_fluxes:        $fluxname$_sms                       
+                    variable_links:                        
+                        output_DIC:           atmocean.A_sms # no DIC reservoir, so wire up to A

--- a/examples/CPU_modular/CPU_modular_examples.jl
+++ b/examples/CPU_modular/CPU_modular_examples.jl
@@ -16,7 +16,7 @@ include("CPU_modular_reactions.jl")
 include("CPU_modular_expts.jl")
 
 # baseline steady-state
-# model = CPU_expts([])
+# model = CPU_modular_expts([])
 
 # LIP CO2 input
 model = CPU_modular_expts([("LIP", 3e18)])

--- a/examples/CPU_modular/CPU_modular_expts.jl
+++ b/examples/CPU_modular/CPU_modular_expts.jl
@@ -1,0 +1,73 @@
+
+
+import PALEOboxes as PB
+import PALEOmodel
+import PALEOcopse
+
+function CPU_modular_expts(expts)
+
+    model = PB.create_model_from_config(
+        joinpath(@__DIR__, "CPU_modular_cfg.yaml"), 
+        "CPU_Zhang2020"; 
+        modelpars=Dict(), # optional Dict can be supplied to set top-level (model wide) Parameters
+    )
+        
+    ###############################################
+    # choose an 'expt' (a delta to the base model)
+    ###############################################
+
+    for expt in expts
+        if expt == "baseline"
+            # baseline configuration
+        elseif length(expt) == 2 && expt[1] == "LIP"
+            # apply 'Witches hat' perturbation given total C input 
+            LIP_total = expt[2] # mol C
+            LIP_peak = 2*LIP_total/0.1e6 # mol C yr-1 at peak
+            F_LIP = PB.get_reaction(model, "global", "F_LIP")
+            # flux is specified as linear interpolation at 'perturb_times'
+            PB.setvalue!(F_LIP.pars.perturb_times,    [-1e30, 0.1e6,  0.15e6,     0.2e6,  1e30])
+            PB.setvalue!(F_LIP.pars.perturb_totals,   [0.0,   0.0,    LIP_peak,   0.0,    0.0]) 
+            PB.setvalue!(F_LIP.pars.perturb_deltas,   [1.0,   1.0,    1.0,        1.0,    1.0].*-5.0)
+
+        elseif length(expt) == 2 && expt[1] == "V"
+            # change V (vegetation) forcing 
+            V_new = expt[2]
+            force_V = PB.get_reaction(model, "global", "force_V")
+            # V is specified as linear interpolation at 'force_times'
+            PB.setvalue!(force_V.pars.force_times,    [-1e30, 0.1e6,  0.2e6,     1e30])
+            PB.setvalue!(force_V.pars.force_values,   [1.0,   1.0,    V_new,     V_new])
+
+        elseif length(expt) == 2 && expt[1] == "E"
+            # change E (vegetation) forcing 
+            E_new = expt[2]
+            force_E = PB.get_reaction(model, "global", "force_E")
+            # V is specified as linear interpolation at 'force_times'
+            PB.setvalue!(force_E.pars.force_times,    [-1e30, 0.1e6,  0.2e6,     1e30])
+            PB.setvalue!(force_E.pars.force_values,   [1.0,   1.0,    E_new,     E_new])                                 
+        else
+            error("unknown expt ", expt)
+        end
+    end
+
+    return model
+end
+
+
+function plot_CPU_modular(output; pager=PALEOmodel.DefaultPlotPager())
+ 
+    pager(
+        plot(output, "global.".*["E", "W", "V", "D"],   title="Forcings", ylabel="normalized forcing"),
+        plot(output, "global.F_LIP",                    title="LIP injection", ylabel="LIP injection (mol C yr-1)"),
+        plot(output, "atmocean.A",                      title="Carbon"),        
+        plot(output, "atm.pCO2PAL",                     title="pCO2", ylabel="pCO2 (PAL)"),
+        plot(output, "land.DeltaT",                     title="Delta T", ylabel="Temperature anomaly (K)"),
+        plot(output, "ocean.f_anoxic",                  title="f_anoxic", ylabel="anoxic fraction (f_anoxic)"),
+        plot(output, "ocean.P_norm",                    title="Phosphorus", ylabel="P/P_0 (normalized)"),
+        plot(output, "ocean.U_norm",                    title="Uranium", ylabel="U/U_0 (normalized)"),
+        plot(output, "ocean.U_delta",                   title="Uranium isotopes", ylabel="delta 238U (per mil)"),
+        plot(output, ["atmocean.A_delta", "atm.CO2_delta", "ocean.DIC_delta"],  title="Carbon isotopes", ylabel="delta 13C (per mil)"),
+    
+        :newpage, # flush any partial page
+    )
+    return nothing
+end

--- a/examples/CPU_modular/CPU_modular_reactions.jl
+++ b/examples/CPU_modular/CPU_modular_reactions.jl
@@ -1,0 +1,341 @@
+module CPU_modular
+
+import PALEOboxes as PB
+
+import Infiltrator # Julia debugger
+
+"""
+    ReactionLandCPU
+
+Land components of minimal Carbon, Phosphorus, Uranium single-box model from [Clarkson2018](@cite), and [Zhang2020](@cite)
+"""
+Base.@kwdef mutable struct ReactionLandCPU{P} <: PB.AbstractReaction
+    base::PB.ReactionBase
+
+    pars::P = PB.ParametersTuple(
+        # Constants for the C, P, U model (Zhang etal 2020, Table 2)
+
+        # Temperature parameters see ReactionGlobalTemperatureBerner
+
+        # Carbon  cycle
+        # A0 see ReactionReservoirScalar A 
+        PB.ParDouble("k_d",         8.0e12, units="mol C/yr",   description="degassing"),
+        PB.ParDouble("k_w",         8.0e12, units="mol C/yr",   description="silicate weathering"),
+        PB.ParDouble("k_ox",        9.0e12, units="mol C/yr",   description="oxidative weathering"),
+        PB.ParDouble("k_carb",      16e12,  units="mol C/yr",   description="carbonate weathering/burial"),
+        PB.ParDouble("k_torg",      4.5e12, units="mol C/yr",   description="terrestrial organic C burial"),
+
+        # Carbon isotopes
+        # delta_LIP see ReactionFluxInterp LIP forcing
+        PB.ParDouble("delta_in",    -5.0,   units="per mil",    description="composition of other inputs"),
+        PB.ParDouble("Delta",       25.0-9.0,   units="per mil",    description="organic fractionation factor relative to atmosphere CO2"),
+
+        # Phosphorus cycle
+        # P0 see ReactionReservoirScalar P
+        PB.ParDouble("k_Pw",        72e9,   units="mol P/yr",   description="phosphorus weathering"),
+
+        # Uranium isotopes
+        # U0 see ReactionReservoirScalar U
+        PB.ParDouble("k_riv",        40e6,  units="mol U/yr",   description="river input"),
+        PB.ParDouble("delta_riv",   -0.26,  units="per mil",    description="Composition of river input"),
+      
+        # isotope configuration
+        # 'external=true' so can be set by global Parameters that apply to the whole model
+        PB.ParType(PB.AbstractData, "CIsotope", PB.ScalarData,
+            external=true,
+            allowed_values=PB.IsotopeTypes,
+            description="disable / enable carbon isotopes and specify isotope type"),
+        PB.ParType(PB.AbstractData, "UIsotope", PB.ScalarData,
+            external=true,
+            allowed_values=PB.IsotopeTypes,
+            description="disable / enable uranium isotopes and specify isotope type"),
+    )
+
+end
+
+
+function PB.register_methods!(rj::ReactionLandCPU)
+ 
+    CIsotopeType = rj.pars.CIsotope[]
+    UIsotopeType = rj.pars.UIsotope[]
+
+    # Variables: 
+    # 'Dep' - an external dependency (forcing, reservoir, ...)
+    # 'Prop' - something we calculate
+    # 'Contrib' - a flux we calculate to add to an external Target (eg a reservoir source - sink)
+    vars = [
+        # Forcings
+        PB.VarDepScalar("global.tforce",   "yr",           "forcing (model) time"),
+        PB.VarDepScalar("global.E",        "",             "normalized E forcing"),
+        PB.VarDepScalar("global.W",        "",             "normalized W forcing"),
+        PB.VarDepScalar("global.V",        "",             "normalized V forcing"),
+        PB.VarDepScalar("global.D",        "",             "normalized D forcing"),     
+        PB.VarDepScalar("atm.pO2PAL","PAL",             "atmospheric oxygen"),
+
+        # additional quantities derived from state variables
+        PB.VarDepScalar("atm.CO2_delta",  "per mil",      "atmosphere CO2 carbon fractionation"),
+        PB.VarDepScalar("atm.pCO2PAL",  "",             "atmospheric pCO2 normalized to present day"),
+        PB.VarDepScalar("global.TEMP",     "K",            "global temperature"),
+
+        # key variables that we calculate
+        PB.VarPropScalar("DeltaT",  "K",            "global temperature relative to 15degC"),
+        PB.VarPropScalar("f_CO2",   "",             "plant CO2 response"),
+        PB.VarPropScalar("f_T",     "",             "weathering kinetics"),
+       
+        # Carbon fluxes
+        PB.VarPropScalar("F_w_norm", "",            "relative silicate weathering"),
+        PB.VarPropScalar("F_w",     "mol C yr-1",   "silicate weathering"),
+        PB.VarPropScalar("F_d",     "mol C yr-1",   "carbonate degassing",
+            attributes=(:field_data=>CIsotopeType,)),
+        PB.VarPropScalar("F_ox",    "mol C yr-1",   "plant CO2 response",
+            attributes=(:field_data=>CIsotopeType,)),
+        PB.VarPropScalar("F_cw",    "mol C yr-1",   "carbonate weathering",
+            attributes=(:field_data=>CIsotopeType,)),
+        PB.VarPropScalar("F_in",    "mol C yr-1",   "aggregate C input",
+            attributes=(:field_data=>CIsotopeType,)),
+        PB.VarPropScalar("F_torg",  "mol C yr-1",   "terrestrial Corg burial",
+            attributes=(:field_data=>CIsotopeType,)),
+
+        # Phosphorus fluxes
+        PB.VarPropScalar("F_Pw",    "mol P yr-1",   "P weathering"),
+
+        # Uranium fluxes
+        PB.VarPropScalar("F_riv",   "mol U yr-1",   "U weathering",
+            attributes=(:field_data=>UIsotopeType,)),
+    ]
+
+    # Add flux couplers
+    fluxAtoLand = PB.Fluxes.FluxContribScalar(
+        "fluxAtoLand.flux_", ["CO2::$CIsotopeType"],
+        isotope_data=Dict())
+
+    fluxRtoOcean = PB.Fluxes.FluxContribScalar(
+        "fluxRtoOcean.flux_", ["DIC::$CIsotopeType", "TAlk", "P", "U::$UIsotopeType"],
+        isotope_data=Dict())
+
+    PB.add_method_do!(
+        rj,
+        do_CPU_land,  
+        (
+            PB.VarList_namedtuple_fields(fluxAtoLand),
+            PB.VarList_namedtuple_fields(fluxRtoOcean),
+            PB.VarList_namedtuple(vars),
+        ),
+        p = (CIsotopeType, UIsotopeType), # provide isotope types here so Julia will generate specialized (fast) code
+    )
+
+    return nothing
+end
+
+
+function do_CPU_land(m::PB.ReactionMethod, pars, (fluxAtoLand, fluxRtoOcean, vars), cellrange::PB.AbstractCellRange, deltat)
+    CIsotopeType, UIsotopeType = m.p # This is (much) faster than rereading Parameters, as Julia generates specialized (fast) code based on the type(s) of p
+
+    # Key variables
+    vars.DeltaT[] = vars.TEMP[] - (15 + PB.Constants.k_CtoK)
+    vars.f_CO2[] = 2*vars.pCO2PAL[]/(1.0 + vars.pCO2PAL[])
+    vars.f_T[] = exp(0.09*vars.DeltaT[])
+
+    # Carbon fluxes
+    vars.F_w_norm[] = vars.E[]*vars.W[]*vars.V[]*vars.f_CO2[]*vars.f_T[]
+    vars.F_w[] = pars.k_w[]*vars.F_w_norm[]
+    vars.F_d[] = @PB.isotope_totaldelta(CIsotopeType,
+        pars.k_d[]*vars.D[], # total
+        pars.delta_in[]) # delta
+    vars.F_ox[] = @PB.isotope_totaldelta(CIsotopeType, 
+        pars.k_ox[], # total
+        pars.delta_in[]) # delta
+    vars.F_cw[] = @PB.isotope_totaldelta(CIsotopeType,
+        pars.k_carb[], # total
+        pars.delta_in[]) # delta
+    vars.F_in[] = vars.F_d[] + vars.F_ox[] + vars.F_cw[]
+
+    vars.F_torg[] = @PB.isotope_totaldelta(CIsotopeType,
+        pars.k_torg[]*vars.V[]*vars.f_CO2[], # total
+        vars.CO2_delta[]-pars.Delta[]) # delta
+   
+    # Phosphorus fluxes
+    vars.F_Pw[] = pars.k_Pw[]*vars.F_w_norm[]
+   
+    # Uranium fluxes
+    vars.F_riv[] = @PB.isotope_totaldelta(UIsotopeType, 
+        pars.k_riv[]*vars.F_w_norm[],  # total
+        pars.delta_riv[])              # delta
+
+    # Fluxes
+    # NB: we don't count C flux from silicate weathering (atm CO2 -> riverine DIC)
+    # as that is just moving carbon from atm to ocean
+
+    # Atmospheric fluxes 
+    fluxAtoLand.CO2[]   += -vars.F_d[] - vars.F_ox[] + vars.F_torg[]
+
+    # Riverine fluxes
+    fluxRtoOcean.DIC[]  += vars.F_cw[] 
+    fluxRtoOcean.TAlk[] += 2*PB.get_total(vars.F_w[]) + 2*PB.get_total(vars.F_cw[])
+    fluxRtoOcean.P[]    += vars.F_Pw[]     
+    fluxRtoOcean.U[]  += vars.F_riv[]
+
+    return nothing
+end
+
+"""
+    ReactionOceanCPU
+
+Ocean component of minimal Carbon, Phosphorus, Uranium single-box model from [Clarkson2018](@cite), and [Zhang2020](@cite)
+"""
+Base.@kwdef mutable struct ReactionOceanCPU{P} <: PB.AbstractReaction
+    base::PB.ReactionBase
+
+    pars::P = PB.ParametersTuple(
+        # Constants for the C, P, U model (Zhang etal 2020, Table 2)
+
+        # Temperature parameters see ReactionGlobalTemperatureBerner
+
+        # Ocean anoxia
+        PB.ParDouble("f_anoxic0",   0.0025, units="",           description="ocean anoxia present day anoxic fraction"),
+        PB.ParDouble("k_anox",      12.0,   units="",           description="ocean anoxia sharpness of transition"),
+        PB.ParDouble("k_u",         0.5,    units="",           description="ocean anoxia nutrient utilization efficiency"),
+
+        # Carbon  cycle
+        # A0 see ReactionReservoirScalar A 
+        PB.ParDouble("k_morg",      4.5e12, units="mol C/yr",   description="marine organic C burial"),
+
+        # Carbon isotopes
+        # delta_LIP see ReactionFluxInterp LIP forcing
+        PB.ParDouble("Delta",       25.0,   units="per mil",    description="organic fractionation factor relative to DIC"),
+
+        # Phosphorus cycle
+        # P0 see ReactionReservoirScalar P
+        PB.ParDouble("k_OrgP",      18e9,   units="mol P/yr",   description="organic P burial"),
+        PB.ParDouble("k_FeP",       18e9,   units="mol P/yr",   description="Iron-sorbed P burial"),
+        PB.ParDouble("k_CaP",       36e9,   units="mol P/yr",   description="Ca-bound P burial"),
+        PB.ParDouble("CPoxic",      250.0,  units="mol/mol",    description="oxic (C/Porg) burial ratio"),
+        PB.ParDouble("CPanoxic",    1000.0, units="mol/mol",    description="anoxic (C/Porg) burial ratio"),
+
+        # Uranium isotopes
+        # U0 see ReactionReservoirScalar U
+        PB.ParDouble("k_anoxic",     6e6,   units="mol U/yr",   description="anoxic sink"),
+        PB.ParDouble("k_other",      34e6,  units="mol U/yr",   description="other sinks combined"),
+        PB.ParDouble("Delta_anoxic", 0.6,   units="per mil",    description="Anoxic sink fractionation"),
+        PB.ParDouble("Delta_other",  0.005, units="per mil",    description="Other sinks fractionation"),
+
+        # isotope configuration
+        # 'external=true' so can be set by global Parameters that apply to the whole model
+        PB.ParType(PB.AbstractData, "CIsotope", PB.ScalarData,
+            external=true,
+            allowed_values=PB.IsotopeTypes,
+            description="disable / enable carbon isotopes and specify isotope type"),
+        PB.ParType(PB.AbstractData, "UIsotope", PB.ScalarData,
+            external=true,
+            allowed_values=PB.IsotopeTypes,
+            description="disable / enable uranium isotopes and specify isotope type"),
+    )
+
+end
+
+
+function PB.register_methods!(rj::ReactionOceanCPU)
+ 
+    CIsotopeType = rj.pars.CIsotope[]
+    UIsotopeType = rj.pars.UIsotope[]
+
+    # Variables: 
+    # 'Dep' - an external dependency (forcing, reservoir, ...)
+    # 'Prop' - something we calculate
+    # 'Contrib' - a flux we calculate to add to an external Target (eg a reservoir source - sink)
+    vars = [
+        # Forcings    
+        PB.VarDepScalar("atm.pO2PAL","PAL",             "atmospheric oxygen"),
+
+        # Special-case a dependency on (riverine) alk flux for carbonate burial
+        PB.VarDepScalar("flux_TAlk"=>"fluxRtoOcean.flux_TAlk",  "mol yr-1"   , "riverine alkalinity flux"),
+
+        # State variables
+        PB.VarDepScalar("P",        "mol P",        "ocean phosphorus"),
+        PB.VarContribScalar("P_sms","mol P yr-1",   "ocean phosphorus source - sink"),
+        PB.VarDepScalar("U",        "mol U",        "ocean uranium",
+            attributes=(:field_data=>UIsotopeType,)),
+        PB.VarContribScalar("U_sms","mol U yr-1",   "ocean uranium source - sink",
+            attributes=(:field_data=>UIsotopeType,)),
+        PB.VarContribScalar("DIC_sms","mol C yr-1",   "ocean DIC source - sink",
+            attributes=(:field_data=>CIsotopeType,)),
+        # additional quantities derived from state variables
+        PB.VarDepScalar("DIC_delta",  "per mil",      "ocean inorganic carbon fractionation"),
+        PB.VarDepScalar("P_norm",   "",             "normalized atm-ocean phosphorus"),
+        PB.VarDepScalar("U_norm",   "",             "normalized ocean uranium"),
+        PB.VarDepScalar("U_delta",  "per mil",      "ocean uranium fractionation"),
+
+        # key variables that we calculate
+        PB.VarPropScalar("f_anoxic","",             "ocean anoxic fraction"),
+        PB.VarPropScalar("CP",      "mol/mol",      "ocean Corg:P burial ratio"),
+
+        # Carbon fluxes
+        PB.VarPropScalar("F_morg",  "mol C yr-1",   "marine Corg burial",
+            attributes=(:field_data=>CIsotopeType,)),
+        PB.VarPropScalar("F_carb",  "mol C yr-1",   "total Ccarb burial",
+            attributes=(:field_data=>CIsotopeType,)),
+
+        # Phosphorus fluxes
+        PB.VarPropScalar("F_OrgP",  "mol P yr-1",   "organic P burial"),
+        PB.VarPropScalar("F_FeP",   "mol P yr-1",   "Fe-sorbed P burial"),
+        PB.VarPropScalar("F_CaP",   "mol P yr-1",   "Ca-bound P burial"),
+
+        # Uranium fluxes
+        PB.VarPropScalar("F_anoxic","mol U yr-1",   "Anoxic U sink",
+            attributes=(:field_data=>UIsotopeType,)),
+        PB.VarPropScalar("F_other", "mol U yr-1",   "Other U sinks",
+            attributes=(:field_data=>UIsotopeType,)),
+    ]
+
+    PB.add_method_do!(
+        rj,
+        do_CPU_ocean,  
+        (
+            PB.VarList_namedtuple(vars),
+        ),
+        p = (CIsotopeType, UIsotopeType), # provide isotope types here so Julia will generate specialized (fast) code
+    )
+
+    return nothing
+end
+
+
+function do_CPU_ocean(m::PB.ReactionMethod, pars, (vars, ), cellrange::PB.AbstractCellRange, deltat)
+    CIsotopeType, UIsotopeType = m.p # This is (much) faster than rereading Parameters, as Julia generates specialized (fast) code based on the type(s) of p
+
+    # Key variables
+    vars.f_anoxic[] = 1.0/(1.0 + exp(-pars.k_anox[]*(pars.k_u[]*vars.P_norm[]-vars.pO2PAL[])))    
+
+    # Carbon fluxes
+    vars.F_morg[] = @PB.isotope_totaldelta(CIsotopeType,
+        pars.k_morg[]*vars.P_norm[], # total
+        vars.DIC_delta[]-pars.Delta[]) # delta
+   
+    vars.F_carb[] = @PB.isotope_totaldelta(CIsotopeType,
+        0.5*vars.flux_TAlk[], # total from instantaneous alkalinity balance
+        vars.DIC_delta[]) # delta assume no fractionation of carbonate burial relative to DIC
+    
+    # Phosphorus fluxes
+    vars.CP[] = vars.f_anoxic[]/pars.CPanoxic[] + (1-vars.f_anoxic[])/pars.CPoxic[]
+    vars.F_OrgP[] = PB.get_total(vars.F_morg[])*vars.CP[]
+    vars.F_FeP[] = pars.k_FeP[]*(1-vars.f_anoxic[])
+    vars.F_CaP[] = pars.k_CaP[]*vars.P_norm[]
+
+    # Uranium fluxes
+    vars.F_anoxic[] = @PB.isotope_totaldelta(UIsotopeType, 
+        pars.k_anoxic[]*vars.U_norm[]*vars.f_anoxic[]/pars.f_anoxic0[], # total
+        vars.U_delta[] + pars.Delta_anoxic[]) # delta
+    vars.F_other[] = @PB.isotope_totaldelta(UIsotopeType,
+        pars.k_other[]*vars.U_norm[]*(1-vars.f_anoxic[])/(1-pars.f_anoxic0[]), # total
+        vars.U_delta[] + pars.Delta_other[]) # delta
+
+
+    # Reservoir source-sink
+    vars.DIC_sms[] -= vars.F_morg[] + vars.F_carb[]
+    vars.P_sms[] -=  vars.F_OrgP[] + vars.F_FeP[] + vars.F_CaP[]
+    vars.U_sms[] -= vars.F_anoxic[] + vars.F_other[]
+
+    return nothing
+end
+
+end # module

--- a/examples/CPU_modular/README.md
+++ b/examples/CPU_modular/README.md
@@ -1,0 +1,33 @@
+# CPU (Carbon, Phosphorus, Uranium) model
+
+These examples demonstrate the CPU model ([Clarkson2018](@cite)) using a modularised configuration in PALEO with parameter values from ([Zhang2020](@cite)).
+
+The model configuration now contains `atm`, `land`, `ocean` Domains in addition to a `global` Domain.  The CPU model itself is split into two pieces, a `ReactionLandCPU` and `ReactionOceanCPU`, connected by fluxes in Domains `fluxRtoOcean` (for `P`, `U`, `DIC`, `TAlk`) and `fluxAtoLand` (for `CO2`).  The `A` reservoir (combined atmosphere and ocean carbon) is placed in an `atmocean` Domain and configured to calculate `CO2_delta` and `DIC_delta` in addition to partitioning of carbon between atmosphere and ocean, with atmosphere `CO2_sms` and ocean `DIC_sms` fluxes rerouted to `A_sms` using `variable_links` in the .yaml file.
+
+## Setting the Julia environment and working directory
+Change the Julia REPL working directory to the `PALEOtutorials/examples/CPU_modular` folder:
+
+In `VS code`, right click on this folder in the file browser and select `Julia: Change to This Directory`. Or from the REPL, use the `cd` command):
+
+    julia> cd("PALEOtutorials/examples/CPU")
+
+If it is not already active, activate the Julia environment `PALEOtutorials/examples`:
+
+In `VS code`, right click on `PALEOtutorials/examples` or any subfolder in the file browser and select `Julia: Activate Parent Environment`. Or from the REPL, use `]` to enter package management:
+
+    julia> pwd()
+    "/home/sd336/software/julia/PALEOtutorials/examples/CPU_modular"
+    julia> ] 
+    (@v1.7) pkg> activate ../
+      Activating project at `/home/sd336/software/julia/PALEOtutorials/examples`
+ 
+## To run the modular CPU example with a default 3e18 mol C perturbation
+   
+    julia> include("CPU_modular_examples.jl")
+
+This will run and plot output (NB: the first run will be slow as Julia JIT compiles the code).
+
+## To display model Parameters, Variables, and output.
+
+See `PALEOmodel` [documentation](https://paleotoolkit.github.io/PALEOmodel.jl/)
+


### PR DESCRIPTION
This uses the CPU model to illustrate PALEO modularisation.

The model configuration now contains `atm`, `land`, `ocean` Domains in addition to a `global` Domain.

The CPU model itself is split into two pieces, a `ReactionLandCPU` and `ReactionOceanCPU`, connected by fluxes in Domains `fluxRtoOcean` (for `P`, `U`, `DIC`, `TAlk`) and `fluxAtoLand` (for `CO2`).